### PR TITLE
Add Fortran Package Manager support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  gcc-build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    env:
+      FC: gfortran
+      GCC_V: 10
+      OMP_NUM_THREADS: 2,1
+      EXAMPLES: >-
+        download
+        gopher
+        http
+        version
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Install GCC (OSX)
+      if: contains(matrix.os, 'macos')
+      run: |
+          ln -s /usr/local/bin/gfortran-${GCC_V} /usr/local/bin/gfortran
+          which gfortran-${GCC_V}
+          which gfortran
+
+    - name: Install GCC (Linux)
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_V} 100 \
+        --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${GCC_V} \
+        --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_V}
+
+    - name: Install libcurl
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+        sudo apt-get install libcurl4-openssl-dev
+
+    - name: Install fpm
+      uses: fortran-lang/setup-fpm@v3
+      with:
+        fpm-version: 'v0.1.3'
+
+    - name: Build (debug)
+      run: fpm build
+
+    - name: Run examples (debug)
+      run: fpm run --example ${EXAMPLES}
+
+    - name: Build (release)
+      run: fpm build --release
+
+    - name: Run examples (debug)
+      run: fpm run --release --example ${EXAMPLES}

--- a/README.md
+++ b/README.md
@@ -65,5 +65,22 @@ $ make <name>
 |---------------------|------------------------|-------|
 | `CURLVERSION_NOW`   | `curl_version_now`     | ✓     |
 
+## Support for fpm
+This projects supports the Fortran package manager ([``fpm``](https://github.com/fortran-lang/fpm)).
+To build the project with ``fpm`` run
+
+```
+fpm build
+```
+
+The example applications are available with the ``fpm run --example`` command.
+
+You can use ``fortran-curl`` in your ``fpm`` projects with
+
+```toml
+[dependencies]
+fortran-curl.git = "https://interkosmos/fortran-curl.git"
+```
+
 ## Licence
 ISC

--- a/examples/download/download.f90
+++ b/examples/download/download.f90
@@ -4,7 +4,7 @@
 !
 ! Author:  Philipp Engel
 ! Licence: ISC
-module callback
+module callback_download
     use :: curl, only: c_f_str_ptr
     implicit none
     private
@@ -54,12 +54,12 @@ contains
         deallocate (chunk)
         response_callback = nmemb
     end function response_callback
-end module callback
+end module callback_download
 
 program main
     use, intrinsic :: iso_c_binding
     use :: curl
-    use :: callback
+    use :: callback_download
     implicit none
 
     character(len=*), parameter :: DEFAULT_PROTOCOL = 'http'

--- a/examples/http/http.f90
+++ b/examples/http/http.f90
@@ -4,7 +4,7 @@
 !
 ! Author:  Philipp Engel
 ! Licence: ISC
-module callback
+module callback_http
     use :: curl, only: c_f_str_ptr
     implicit none
     private
@@ -60,12 +60,12 @@ contains
         deallocate (tmp)
         response_callback = nmemb
     end function response_callback
-end module callback
+end module callback_http
 
 program main
     use, intrinsic :: iso_c_binding
     use :: curl
-    use :: callback
+    use :: callback_http
     implicit none
 
     character(len=*), parameter :: DEFAULT_PROTOCOL = 'http'

--- a/examples/imap/imap.f90
+++ b/examples/imap/imap.f90
@@ -7,7 +7,7 @@
 !
 ! Author:  Philipp Engel
 ! Licence: ISC
-module callback
+module callback_imap
     use, intrinsic :: iso_c_binding
     use :: curl, only: c_f_str_ptr
     implicit none
@@ -40,12 +40,12 @@ contains
 
         write_callback = nmemb
     end function write_callback
-end module callback
+end module callback_imap
 
 program main
     use, intrinsic :: iso_c_binding
     use :: curl
-    use :: callback
+    use :: callback_imap
     implicit none
 
     character(len=*), parameter :: URL      = 'imaps://example.com' ! IMAP server (SSL).

--- a/examples/smtp/smtp.f90
+++ b/examples/smtp/smtp.f90
@@ -7,7 +7,7 @@
 !
 ! Author:  Philipp Engel
 ! Licence: ISC
-module callback
+module callback_smtp
     use, intrinsic :: iso_c_binding
     implicit none
     private
@@ -71,12 +71,12 @@ contains
         ! Return the copied bytes.
         upload_callback = n
     end function upload_callback
-end module callback
+end module callback_smtp
 
 program main
     use, intrinsic :: iso_c_binding
     use :: curl
-    use :: callback
+    use :: callback_smtp
     implicit none
 
     character(len=*), parameter :: CRLF     = achar(13) // achar(10) // c_null_char

--- a/examples/version/version.f90
+++ b/examples/version/version.f90
@@ -7,7 +7,6 @@
 program main
     use, intrinsic :: iso_c_binding
     use :: curl
-    use :: callback
     implicit none
     character(len=64)           :: host, vcurl, vssl
     type(curl_version), pointer :: data

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,0 +1,40 @@
+name = "fortran-curl"
+license = "ISC"
+author = "Philipp Engel"
+maintainer = "@interkosmos"
+copyright = "Copyright (c) 2020, Philipp Engel"
+description = "Fortran 2008 ISO C binding interfaces to libcurl"
+keywords = ["curl", "libcurl", "http", "gopher", "smtp", "imap"]
+
+[build]
+link = "curl"
+
+[[example]]
+name = "download"
+source-dir = "examples/download"
+main = "download.f90"
+
+[[example]]
+name = "gopher"
+source-dir = "examples/gopher"
+main = "gopher.f90"
+
+[[example]]
+name = "http"
+source-dir = "examples/http"
+main = "http.f90"
+
+[[example]]
+name = "imap"
+source-dir = "examples/imap"
+main = "imap.f90"
+
+[[example]]
+name = "smtp"
+source-dir = "examples/smtp"
+main = "smtp.f90"
+
+[[example]]
+name = "version"
+source-dir = "examples/version"
+main = "version.f90"


### PR DESCRIPTION
This PR adds support for the Fortran Package Manager ([fpm](https://github.com/fortran-lang/fpm)) to this project. It also includes a CI setup with GitHub actions for Ubuntu and OSX to make it easier to maintain the fpm support.

Feel free to merge, adapt or just close this PR (whatever you prefer).