### PR TITLE
Add CURL_ZERO_TERMINATED

### DIFF
--- a/src/curl.f90
+++ b/src/curl.f90
@@ -10,6 +10,7 @@ module curl
     implicit none
     private
 
+    integer(kind=i8)   , parameter, public :: CURL_ZERO_TERMINATED      = -1
     integer(kind=c_int), parameter, public :: CURLOPTTYPE_LONG          = 0
     integer(kind=c_int), parameter, public :: CURLOPTTYPE_OBJECTPOINT   = 10000
     integer(kind=c_int), parameter, public :: CURLOPTTYPE_FUNCTIONPOINT = 20000


### PR DESCRIPTION
`CURL_ZERO_TERMINATED` is a constant flag that is defined in the libcurl library. It is used in `curl_mime_data` function as 3rd argument to indicate that the data being transferred is a null-terminated string.