### PR TITLE
Remove interface to variadic curl_easy_setopt

### DIFF
--- a/src/curl.f90
+++ b/src/curl.f90
@@ -663,7 +663,7 @@ module curl
         end function curl_easy_perform
 
         ! CURLcode curl_easy_setopt(CURL *curl, CURLoption option, ...)
-        function curl_easy_setopt_c_char(curl, option, parameter) bind(c, name='curl_easy_setopt')
+        function curl_easy_setopt_c_char(curl, option, parameter) bind(c, name='curl_easy_setopt_c_char')
             import :: c_char, c_int, c_ptr
             implicit none
             type(c_ptr),            intent(in), value :: curl
@@ -673,7 +673,7 @@ module curl
         end function curl_easy_setopt_c_char
 
         ! CURLcode curl_easy_setopt(CURL *curl, CURLoption option, ...)
-        function curl_easy_setopt_c_long(curl, option, parameter) bind(c, name='curl_easy_setopt')
+        function curl_easy_setopt_c_long(curl, option, parameter) bind(c, name='curl_easy_setopt_c_long')
             import :: c_int, c_long, c_ptr
             implicit none
             type(c_ptr),          intent(in), value :: curl
@@ -683,7 +683,7 @@ module curl
         end function curl_easy_setopt_c_long
 
         ! CURLcode curl_easy_setopt(CURL *curl, CURLoption option, ...)
-        function curl_easy_setopt_c_ptr(curl, option, parameter) bind(c, name='curl_easy_setopt')
+        function curl_easy_setopt_c_ptr(curl, option, parameter) bind(c, name='curl_easy_setopt_c_ptr')
             import :: c_int, c_ptr
             implicit none
             type(c_ptr),         intent(in), value :: curl
@@ -693,7 +693,7 @@ module curl
         end function curl_easy_setopt_c_ptr
 
         ! CURLcode curl_easy_setopt(CURL *curl, CURLoption option, ...)
-        function curl_easy_setopt_c_funptr(curl, option, parameter) bind(c, name='curl_easy_setopt')
+        function curl_easy_setopt_c_funptr(curl, option, parameter) bind(c, name='curl_easy_setopt_c_funptr')
             import :: c_funptr, c_int, c_ptr
             implicit none
             type(c_ptr),         intent(in), value :: curl

--- a/src/curl_macro.c
+++ b/src/curl_macro.c
@@ -6,3 +6,25 @@ int curl_version_now()
 {
     return CURLVERSION_NOW;
 }
+
+/* Non-variadic Wrappers to curl_easy_setopt */
+int curl_easy_setopt_c_int(CURL *curl, CURLoption option, int value)
+{
+    return curl_easy_setopt(curl, option, value);
+}
+int curl_easy_setopt_c_long(CURL *curl, CURLoption option, long value)
+{
+    return curl_easy_setopt(curl, option, value);
+}
+int curl_easy_setopt_c_ptr(CURL *curl, CURLoption option, void* value)
+{
+    return curl_easy_setopt(curl, option, value);
+}
+int curl_easy_setopt_c_char(CURL *curl, CURLoption option, char* value)
+{
+    return curl_easy_setopt(curl, option, value);
+}
+int curl_easy_setopt_c_funptr(CURL *curl, CURLoption option, void* value)
+{
+    return curl_easy_setopt(curl, option, value);
+}


### PR DESCRIPTION
Fixes #11 on my machine. 

It seems like everything works if Fortran is never asked to call a variadic function directly. 
So I propose to write the type-specific interface on the C side instead.