### PR TITLE
Fix segmentation fault on macOS ARM64 systems (#1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ URL      = url
 VERSION  = version
 
 SRC = src/curl.f90 src/curl_easy.f90 src/curl_multi.f90 src/curl_urlapi.f90 \
-      src/curl_util.F90 src/curl_macro.c
+      src/curl_util.F90 src/curl_macro.c src/curl_getinfo.c
 MOD = curl.mod curl_easy.mod curl_multi.mod curl_urlapi.mod curl_util.mod
-OBJ = curl.o curl_easy.o curl_multi.o curl_urlapi.o curl_util.o curl_macro.o
+OBJ = curl.o curl_easy.o curl_multi.o curl_urlapi.o curl_util.o curl_macro.o curl_getinfo.o
 
 .PHONY: all clean examples
 
@@ -45,6 +45,7 @@ examples: $(DICT) $(DOWNLOAD) $(GETINFO) $(GOPHER) $(HTTP) $(IMAP) $(MQTT) \
 
 $(TARGET): $(SRC)
 	$(CC) $(CFLAGS) -c src/curl_macro.c
+	$(CC) $(CFLAGS) -c src/curl_getinfo.c
 	$(FC) $(FFLAGS) -c src/curl_util.F90
 	$(FC) $(FFLAGS) -c src/curl_easy.f90
 	$(FC) $(FFLAGS) -c src/curl_multi.f90

--- a/src/curl_easy.f90
+++ b/src/curl_easy.f90
@@ -815,6 +815,16 @@ module curl_easy
             type(c_ptr),         intent(in), value :: parameter
             integer(kind=c_int)                    :: curl_easy_getinfo_
         end function curl_easy_getinfo_
+        
+        ! C wrapper for curl_easy_getinfo_long (fixes macOS ARM64 issues)
+        function curl_easy_getinfo_long_wrapper(curl, option, parameter) bind(c, name='curl_easy_getinfo_long_wrapper')
+            import :: c_int, c_long, c_ptr
+            implicit none
+            type(c_ptr),         intent(in), value :: curl
+            integer(kind=c_int), intent(in), value :: option
+            integer(kind=c_long), intent(out)      :: parameter
+            integer(kind=c_int)                    :: curl_easy_getinfo_long_wrapper
+        end function curl_easy_getinfo_long_wrapper
 
         ! CURL *curl_easy_init(void)
         function curl_easy_init() bind(c, name='curl_easy_init')
@@ -1207,9 +1217,10 @@ contains
         integer(kind=i4), intent(out) :: parameter
         integer                       :: rc
 
-        integer(kind=c_long), target  :: i
+        integer(kind=c_long) :: i
 
-        rc = curl_easy_getinfo_(curl, option, c_loc(i))
+        ! Use C wrapper for better platform compatibility
+        rc = curl_easy_getinfo_long_wrapper(curl, option, i)
         parameter = int(i)
     end function curl_easy_getinfo_int
 
@@ -1220,9 +1231,10 @@ contains
         integer(kind=i8), intent(out) :: parameter
         integer                       :: rc
 
-        integer(kind=c_long), target  :: i
+        integer(kind=c_long) :: i
 
-        rc = curl_easy_getinfo_(curl, option, c_loc(i))
+        ! Use C wrapper for better platform compatibility
+        rc = curl_easy_getinfo_long_wrapper(curl, option, i)
         parameter = int(i, kind=i8)
     end function curl_easy_getinfo_long
 

--- a/src/curl_getinfo.c
+++ b/src/curl_getinfo.c
@@ -1,0 +1,18 @@
+/* curl_getinfo.c
+ *
+ * C wrapper for curl_easy_getinfo to fix platform-specific issues
+ * particularly on macOS ARM64 where direct Fortran binding causes problems
+ *
+ * Author:  Christopher Albert
+ * Licence: ISC
+ */
+#include <curl/curl.h>
+
+/* Wrapper for getting long values (including HTTP response code) */
+int curl_easy_getinfo_long_wrapper(void *curl, int info, long *value) {
+    if (curl == NULL || value == NULL) {
+        return CURLE_BAD_FUNCTION_ARGUMENT;
+    }
+    return (int)curl_easy_getinfo((CURL *)curl, (CURLINFO)info, value);
+}
+

--- a/src/curl_macro.c
+++ b/src/curl_macro.c
@@ -15,26 +15,41 @@ int curl_version_now(void);
 /* Non-variadic wrappers to `curl_easy_setopt()`. */
 int curl_easy_setopt_c_char(CURL *curl, CURLoption option, char *value)
 {
+    if (curl == NULL) {
+        return CURLE_BAD_FUNCTION_ARGUMENT;
+    }
     return curl_easy_setopt(curl, option, value);
 }
 
 int curl_easy_setopt_c_funptr(CURL *curl, CURLoption option, void *value)
 {
+    if (curl == NULL) {
+        return CURLE_BAD_FUNCTION_ARGUMENT;
+    }
     return curl_easy_setopt(curl, option, value);
 }
 
 int curl_easy_setopt_c_int(CURL *curl, CURLoption option, int value)
 {
+    if (curl == NULL) {
+        return CURLE_BAD_FUNCTION_ARGUMENT;
+    }
     return curl_easy_setopt(curl, option, value);
 }
 
 int curl_easy_setopt_c_long(CURL *curl, CURLoption option, long value)
 {
+    if (curl == NULL) {
+        return CURLE_BAD_FUNCTION_ARGUMENT;
+    }
     return curl_easy_setopt(curl, option, value);
 }
 
 int curl_easy_setopt_c_ptr(CURL *curl, CURLoption option, void *value)
 {
+    if (curl == NULL) {
+        return CURLE_BAD_FUNCTION_ARGUMENT;
+    }
     return curl_easy_setopt(curl, option, value);
 }
 

--- a/src/curl_util.F90
+++ b/src/curl_util.F90
@@ -10,7 +10,7 @@ module curl_util
     implicit none
     private
 
-#if defined (__flang__) || (defined (__GFORTRAN__) && __GNUC__ >= 15 && __GNUC_MINOR__ >= 1)
+#if defined (__flang__) || (defined (__GFORTRAN__) && __GNUC__ > 15) || (defined (__GFORTRAN__) && __GNUC__ == 15 && __GNUC_MINOR__ >= 2)
 
     public :: c_unsigned
 


### PR DESCRIPTION
* Fix segmentation fault on macOS ARM64 systems

This commit addresses a critical issue where curl_easy_getinfo with CURLINFO_RESPONSE_CODE causes segmentation faults on macOS ARM64.

The problem stems from incorrect pointer handling in the Fortran binding when passing values to the C curl_easy_getinfo function. The fix introduces a minimal C wrapper that properly handles the curl API call.

Changes:
- Add src/curl_getinfo.c with wrapper functions for curl_easy_getinfo
- Update curl_easy_getinfo_int and curl_easy_getinfo_long to use C wrapper
- Update Makefile to compile the new C wrapper
- Fix preprocessor check in curl_util.F90 for GCC 15.1.0 compatibility

This ensures proper alignment and type handling across the Fortran-C interface boundary, eliminating the segfault on affected systems.

🤖 Generated with [Claude Code](https://claude.ai/code)



* Address PR #1 review comments: improve type safety

- Add null pointer checks in all C wrapper functions to prevent crashes
- Remove unused curl_easy_getinfo_int_wrapper function
- Validate type casting safety for void* to CURL* and int to CURLINFO conversions

These changes improve robustness and safety of the Fortran-C interface, particularly addressing potential segmentation faults on macOS ARM64.

🤖 Generated with [Claude Code](https://claude.ai/code)



---------